### PR TITLE
Fix potential overflow in `refill` method

### DIFF
--- a/packages/solana/contracts/programs/oft/src/state/peer.rs
+++ b/packages/solana/contracts/programs/oft/src/state/peer.rs
@@ -35,7 +35,8 @@ impl RateLimiter {
         let current_time: u64 = Clock::get()?.unix_timestamp.try_into().unwrap();
         if current_time > self.last_refill_time {
             let time_elapsed_in_seconds = current_time - self.last_refill_time;
-            new_tokens += time_elapsed_in_seconds * self.refill_per_second;
+            new_tokens = new_tokens
+                .saturating_add(time_elapsed_in_seconds.saturating_mul(self.refill_per_second));
         }
         self.tokens = std::cmp::min(self.capacity, self.tokens.saturating_add(new_tokens));
 
@@ -49,7 +50,7 @@ impl RateLimiter {
             Some(new_tokens) => {
                 self.tokens = new_tokens;
                 Ok(())
-            },
+            }
             None => Err(error!(OftError::RateLimitExceeded)),
         }
     }


### PR DESCRIPTION
#### Summary
This PR addresses a potential overflow issue in the `refill` method. The issue arises when the `refill_per_second` value is large, and the time elapsed between two refills is significant.
https://github.com/LayerZero-Labs/example-oft/blob/fc949393514e36e9616a9fcd2734ef795cb43c9b/packages/solana/contracts/programs/oft/src/state/peer.rs#L33-L44

#### Problem
If the `refill_per_second` value is set to a high number, such as `2,777,777,777,778`, and the time elapsed between two refills is `6,652,800(77 days)`, the calculation `time_elapsed_in_seconds * refill_per_second` can exceed the maximum value of `u64（approximately 1.84E19)`, causing an overflow.

#### Solution
We use the `saturating_add` and `saturating_mul` methods to prevent this overflow and ensure that the addition and multiplication operations do not exceed the u64 limit. These methods will saturate at the maximum value of u64 instead of overflowing.

